### PR TITLE
fix: 修复了avl树删除时候缺失的逻辑

### DIFF
--- a/src/main/java/DataStructure/Tree/AVLTree.java
+++ b/src/main/java/DataStructure/Tree/AVLTree.java
@@ -166,13 +166,30 @@ public class AVLTree<T extends SrchTreeSampleAble> implements TreeAble<T>, Itera
                 Note<T> successorNote = upDateNotePath.pollTail();
                 Note<T> successorParent = upDateNotePath.peekTail();
                 deleteNote.value = successorNote.value;
-                if(successorParent != null) {
 
-                    successorParent.left = null;
+                if(isLeafNote(successorNote)) {
+
+                    if(successorParent != null) {
+
+                        successorParent.left = null;
+
+                    }else {
+
+                        deleteNote.right = null;
+
+                    }
 
                 }else {
 
-                    deleteNote.right = null;
+                    if(successorParent != null) {
+
+                        successorParent.left = successorNote.right;
+
+                    }else {
+
+                        deleteNote.right = successorNote.right;;
+
+                    }
 
                 }
 
@@ -182,13 +199,30 @@ public class AVLTree<T extends SrchTreeSampleAble> implements TreeAble<T>, Itera
                 Note<T> precursor = upDateNotePath.pollTail();
                 Note<T> precursorParent = upDateNotePath.peekTail();
                 deleteNote.value = precursor.value;
-                if(precursorParent != null) {
 
-                    precursorParent.right = null;
+                if(isLeafNote(precursor)) {
+
+                    if(precursorParent != null) {
+
+                        precursorParent.right = null;
+
+                    }else {
+
+                        deleteNote.left = null;
+
+                    }
 
                 }else {
 
-                    deleteNote.left = null;
+                    if(precursorParent != null) {
+
+                        precursorParent.right = parentNote.left;
+
+                    }else {
+
+                        deleteNote.left = parentNote.left;
+
+                    }
 
                 }
 

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -27,6 +27,8 @@ public class Main {
     @Test
     public void test() {
 
+        avlTree.delete(new Sample(3));
+
         System.out.println("广度遍历-——-——-——-——-——");
         avlTree.breadthOrder();
         System.out.println();


### PR DESCRIPTION
修复当前驱或者后继节点被删除时，未判断其是否为叶子节点